### PR TITLE
Perform major refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,13 @@ edition = "2018"
 [dependencies]
 lieutenant-macros = { path =  "macros" }
 
-anyhow = "1.0"
-thiserror = "1.0"
 slab = "0.4"
 smallvec = "1.4"
-async-trait = "0.1"
+derivative = "2.1"
 
 [dev-dependencies]
 criterion = "0.3"
-smol = "0.1"
-futures = "0.3"
-thread_local = "1.0"
+thiserror = "1.0"
 
 [[bench]]
 name = "dispatcher"

--- a/benches/dispatcher.rs
+++ b/benches/dispatcher.rs
@@ -27,7 +27,7 @@ fn single_command(c: &mut Criterion) {
         type Ok = ();
     }
     #[command(usage = "command")]
-    async fn command(_: &mut State) -> Result<(), Error> {
+    fn command(_: &mut State) -> Result<(), Error> {
         // thread::sleep(time::Duration::from_millis(1));
         Ok(())
     }
@@ -35,18 +35,11 @@ fn single_command(c: &mut Criterion) {
     let mut dispatcher = CommandDispatcher::default();
     dispatcher.register(command).unwrap();
 
-    let mut nodes = Vec::new();
-    let mut errors = Vec::new();
-
     c.bench_function("dispatch single command", |b| {
         b.iter(|| {
-            assert!(smol::block_on(dispatcher.dispatch(
-                &mut nodes,
-                &mut errors,
-                &mut State,
-                black_box("command")
-            ))
-            .is_ok());
+            assert!(dispatcher
+                .dispatch(&mut State, black_box("command"))
+                .is_ok());
         })
     });
 }
@@ -106,31 +99,31 @@ fn multiple_commands(c: &mut Criterion) {
         type Ok = ();
     }
     #[command(usage = "command")]
-    async fn command_1(_state: &mut State) -> Result<(), Error> {
+    fn command_1(_state: &mut State) -> Result<(), Error> {
         // thread::sleep(time::Duration::from_millis(1));
         Ok(())
     }
 
     #[command(usage = "command <a>")]
-    async fn command_2(_state: &mut State, _a: i32) -> Result<(), Error> {
+    fn command_2(_state: &mut State, _a: i32) -> Result<(), Error> {
         // thread::sleep(time::Duration::from_millis(1));
         Ok(())
     }
 
     #[command(usage = "command <a> <b>")]
-    async fn command_3(_state: &mut State, _a: i32, _b: String) -> Result<(), Error> {
+    fn command_3(_state: &mut State, _a: i32, _b: String) -> Result<(), Error> {
         // thread::sleep(time::Duration::from_millis(1));
         Ok(())
     }
 
     #[command(usage = "command <a> <b>")]
-    async fn command_4(_state: &mut State, _a: String, _b: String) -> Result<(), Error> {
+    fn command_4(_state: &mut State, _a: String, _b: String) -> Result<(), Error> {
         // thread::sleep(time::Duration::from_millis(1));
         Ok(())
     }
 
     #[command(usage = "command <a> <b> <c>")]
-    async fn command_5(_state: &mut State, _a: i32, _b: i32, _c: i32) -> Result<(), Error> {
+    fn command_5(_state: &mut State, _a: i32, _b: i32, _c: i32) -> Result<(), Error> {
         // thread::sleep(time::Duration::from_millis(1));
         Ok(())
     }
@@ -142,53 +135,16 @@ fn multiple_commands(c: &mut Criterion) {
         .with(command_4)
         .with(command_5);
 
-    let mut nodes = Vec::new();
-    let mut errors = Vec::new();
-
     c.bench_function("dispatch multiple commands", |b| {
         b.iter(|| {
-            assert!(smol::block_on(dispatcher.dispatch(
-                &mut nodes,
-                &mut errors,
-                &mut State,
-                "command"
-            ))
-            .is_ok());
-            assert!(smol::block_on(dispatcher.dispatch(
-                &mut nodes,
-                &mut errors,
-                &mut State,
-                "command 4"
-            ))
-            .is_ok());
-            assert!(smol::block_on(dispatcher.dispatch(
-                &mut nodes,
-                &mut errors,
-                &mut State,
-                "command 4 hello"
-            ))
-            .is_ok());
-            assert!(smol::block_on(dispatcher.dispatch(
-                &mut nodes,
-                &mut errors,
-                &mut State,
-                "command hello hello"
-            ))
-            .is_ok());
-            assert!(smol::block_on(dispatcher.dispatch(
-                &mut nodes,
-                &mut errors,
-                &mut State,
-                "command 4 4 4"
-            ))
-            .is_ok());
-            assert!(smol::block_on(dispatcher.dispatch(
-                &mut nodes,
-                &mut errors,
-                &mut State,
-                "command a a a"
-            ))
-            .is_err());
+            assert!(dispatcher.dispatch(&mut State, "command").is_ok());
+            assert!(dispatcher.dispatch(&mut State, "command 4").is_ok());
+            assert!(dispatcher.dispatch(&mut State, "command 4 hello").is_ok());
+            assert!(dispatcher
+                .dispatch(&mut State, "command hello hello")
+                .is_ok());
+            assert!(dispatcher.dispatch(&mut State, "command 4 4 4").is_ok());
+            assert!(dispatcher.dispatch(&mut State, "command a a a").is_err());
         })
     });
 }

--- a/macros/src/provider.rs
+++ b/macros/src/provider.rs
@@ -59,15 +59,15 @@ fn verify_input(input: &ItemFn) {
         );
     }
 
-    // must be async
-    if input.sig.asyncness.is_none() {
-        let span = input.sig.fn_token.span();
+    // must not be async
+    if let Some(asyncness) = input.sig.asyncness {
+        let span = asyncness.span();
         let name = &input.sig.ident;
 
         emit_error!(
-            span, "provider function must be `async`";
+            span, "provider function must not be `async`";
 
-            help = "make the function async: `async fn {}`", name
+            help = "remove the `async` keyword: `fn {}`", name
         );
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,27 +1,51 @@
-use crate::{ArgumentChecker, Context};
+use crate::parser::SatisfiesFn;
+use crate::Context;
+use derivative::Derivative;
 use smallvec::SmallVec;
+use std::any::TypeId;
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::future::Future;
-use std::pin::Pin;
 
+/// A type which can be converted into a `CommandSpec`.
+///
+/// This is automatically implemented for functions annotated
+/// with the `command` proc macro.
 pub trait Command<C: Context> {
-    /// Returns the root node for parsing this command.
+    /// Returns the spec of this command, which specifies
+    /// its arguments and executable function.
     fn build(self) -> CommandSpec<C>;
 }
 
+/// An argument to a command.
+#[derive(Derivative)]
+#[derivative(Clone(bound = ""))]
 pub enum Argument<C: Context> {
+    /// A literal, matching some fixed string value.
+    ///
+    /// Multiple strings may match the same literal
+    /// argument, to allow for aliasing.
     Literal {
+        /// The set of strings which match this literal.
         values: SmallVec<[Cow<'static, str>; 2]>,
     },
+    /// A custom-parsed argument.
     Parser {
+        /// Name of this argument.
         name: Cow<'static, str>,
-        checker: Box<dyn ArgumentChecker<C>>,
+        /// Priority of this argument. Greater priorities
+        /// take precedence over command nodes with lower
+        /// priorities.
         priority: usize,
+        /// The function used to check whether
+        /// a given input matches this parser.
+        satisfies: SatisfiesFn<C>,
+        /// Type ID of the argument type.
+        argument_type: TypeId,
     },
 }
 
 impl<C: Context> Argument<C> {
+    /// Returns the priority of this argument node.
     pub fn priority(&self) -> usize {
         match self {
             Argument::Literal { .. } => 0,
@@ -30,70 +54,51 @@ impl<C: Context> Argument<C> {
     }
 }
 
-impl<C: Context> Clone for Argument<C> {
-    fn clone(&self) -> Self {
-        match self {
-            Argument::Literal { values } => Argument::Literal {
-                values: values.clone(),
-            },
-            Argument::Parser {
-                name,
-                checker,
-                priority,
-            } => Argument::Parser {
-                name: name.clone(),
-                checker: checker.box_clone(),
-                priority: *priority,
-            },
-        }
-    }
-}
-
-impl<C: Context> PartialEq for Argument<C>
+impl<C> PartialEq for Argument<C>
 where
     C: Context,
 {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Argument::Literal { values }, Argument::Literal { values: other }) => values == other,
-            (Argument::Parser { checker, .. }, Argument::Parser { checker: other, .. }) => {
-                checker.equals(other)
-            }
-            (_, _) => false,
+            (Argument::Literal { values: v1 }, Argument::Literal { values: v2 }) => v1 == v2,
+            (
+                Argument::Parser {
+                    argument_type: s1, ..
+                },
+                Argument::Parser {
+                    argument_type: a2, ..
+                },
+            ) => s1 == a2,
+            _ => false,
         }
     }
 }
 
-impl<C: Context> Eq for Argument<C> where C: 'static {}
+impl<C> Eq for Argument<C> where C: Context {}
 
-impl<C: Context> PartialOrd for Argument<C>
-where
-    C: 'static,
-{
+impl<C: Context> PartialOrd for Argument<C> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<C: Context> Ord for Argument<C>
-where
-    C: 'static,
-{
+impl<C: Context> Ord for Argument<C> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.priority().cmp(&other.priority())
     }
 }
 
-pub type Exec<C> = for<'a> fn(
-    &'a mut C,
-    &'a str,
-) -> Pin<
-    Box<dyn Future<Output = Result<<C as Context>::Ok, <C as Context>::Error>> + Send + 'a>,
->;
+pub type Exec<C> = fn(&mut C, &str) -> Result<<C as Context>::Ok, <C as Context>::Error>;
 
+/// Specifies the arguments to a command,
+/// plus its metadata and executable function.
 pub struct CommandSpec<C: Context> {
+    /// Argument nodes to this command. This is a list,
+    /// not a graph.
     pub arguments: Vec<Argument<C>>,
+    /// Description of this command, potentially nonexistent.
     pub description: Option<Cow<'static, str>>,
+    /// THe function used to execute this command.
     pub exec: Exec<C>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod provider;
 pub use command::{Argument, Command, CommandSpec};
 pub use dispatcher::CommandDispatcher;
 pub use lieutenant_macros::{command, provider};
-pub use parser::{parsers, ArgumentChecker, ArgumentKind, ArgumentParser, ParserUtil};
+pub use parser::{ArgumentKind, Input};
 pub use provider::{Provideable, Provider};
 
 /// Denotes a type that may be passed to commands as input.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,7 +13,7 @@ impl<'a> Input<'a> {
 
     /// Advances the pointer until the given pattern has been reached, returning
     /// the consumed characters.
-    pub fn advance_until(&mut self, pat: &str) -> &str {
+    pub fn advance_until<'b>(&'b mut self, pat: &str) -> &'a str {
         let head = self.ptr.split(pat).next().unwrap_or("");
         self.ptr = &self.ptr[(head.len() + pat.len()).min(self.ptr.len())..];
         head


### PR DESCRIPTION
This PR resolves a number of problems I've had with the library.

* Simplified the `ArgumentChecker`, `ArgumentKind`, and `ArgumentParser` system by merging all three into a single `ArgumentKind` trait which defines all funtions.
* Removed the auxilary functions `box_clone` and `default` for the `Argument*` traits.
* Removed async support. I realized that supporting async in `lieutenant` is unnecessary with how the Feather task system works. In Feather, a command which needs to perform async operations can call `task::spawn()` to spawn an async task.
  * Why? The old system supported async commands in first class. However, the _vast_ majority of commands in Feather will never need async—they only need to interact with game state. As such, I realized we should support synchronous commands natively, while having async commands spawn a task themselves, rather than the other way around. The removal of async support in `lieutenant` also removed significant complexity, and it improves performance by eliminating the boxing of `Future`s.
    * Eliminating `async` also improves integration with non-Feather users, who are unlikely to have any use for it in the first place.

Additionally, I added some documentation here and there.